### PR TITLE
feat: sql `on index` support with drizzle

### DIFF
--- a/packages/toolchain/src/build/gen/db_schema.ts
+++ b/packages/toolchain/src/build/gen/db_schema.ts
@@ -56,6 +56,11 @@ async function generateSchemaHelper(module: Module, path: string, ormPackage: st
   export const schema = pgSchema(${JSON.stringify(module.db?.schema)});
   `;
 
+	// Re-export indexing abilities
+	helper.append`
+  export { index } from ${JSON.stringify(`${ormPackage}/pg-core`)};
+  `;
+
 	// Re-export database types
 	helper.append`
   export * as Query from ${JSON.stringify(helper.relative(ormReexportPath))};

--- a/packages/toolchain/src/build/gen/db_schema.ts
+++ b/packages/toolchain/src/build/gen/db_schema.ts
@@ -58,7 +58,7 @@ async function generateSchemaHelper(module: Module, path: string, ormPackage: st
 
 	// Re-export indexing abilities
 	helper.append`
-  export { index } from ${JSON.stringify(`${ormPackage}/pg-core`)};
+  export { index, uniqueIndex } from ${JSON.stringify(`${ormPackage}/pg-core`)};
   `;
 
 	// Re-export database types


### PR DESCRIPTION
Allows more advanced schemas such as
```ts
const events = schema.table("notes", {
    id: ...,
    time: ...,
}, (table) => ({
    eventId: uniqueIndex("event_id").on(table.id),
    eventNameId: index("event_id").on(table.id, Query.desc(table.time))
}));
```